### PR TITLE
Add workaorund to prevent Wan2.1 scheduler error when using Pytorch (ROCm)

### DIFF
--- a/comfy/extra_samplers/uni_pc.py
+++ b/comfy/extra_samplers/uni_pc.py
@@ -3,6 +3,7 @@
 import torch
 import math
 import logging
+import numpy as np
 
 from tqdm.auto import trange
 
@@ -640,7 +641,11 @@ class UniPC:
                 if order == 2:
                     rhos_p = torch.tensor([0.5], device=b.device)
                 else:
-                    rhos_p = torch.linalg.solve(R[:-1, :-1], b[:-1])
+                    R_np = R[:-1, :-1].detach().cpu().numpy()
+                    b_np = b[:-1].detach().cpu().numpy()
+                    rhos_p_np = np.linalg.solve(R_np, b_np)
+                    rhos_p = torch.from_numpy(rhos_p_np).to(R.device).to(x.dtype)
+
         else:
             D1s = None
 
@@ -650,7 +655,10 @@ class UniPC:
             if order == 1:
                 rhos_c = torch.tensor([0.5], device=b.device)
             else:
-                rhos_c = torch.linalg.solve(R, b)
+                R_np = R.detach().cpu().numpy()
+                b_np = b.detach().cpu().numpy()
+                rhos_c_np = np.linalg.solve(R_np, b_np)
+                rhos_c = torch.from_numpy(rhos_c_np).to(R.device).to(x.dtype)
 
         model_t = None
         if self.predict_x0:


### PR DESCRIPTION
Add workaorund to prevent Wan2.1 scheduler error when using Pytorch (ROCm)

The `torch.linalg.solve` is not support yet in Pytorch (ROCm) 20250815 (TheRock package) , Add this workaorund to run same opartion in numpy.
<img width="980" height="132" alt="{6E3A4F61-7A68-43E2-BED9-EB5AC16ABE34}" src="https://github.com/user-attachments/assets/55e0537d-963f-4fbb-9d40-549846be1a84" />

<img width="980" height="177" alt="{E28195B5-1AC1-4225-9909-D97E35EBCC18}" src="https://github.com/user-attachments/assets/32f804ae-0af4-421b-8e1e-5188d5710b57" />
